### PR TITLE
Migrates services from Context.Tag to Effect.Service

### DIFF
--- a/src/lib/components/Head.svelte
+++ b/src/lib/components/Head.svelte
@@ -57,9 +57,6 @@
 	}
 
 	const headerData = $derived.by(() => {
-		const paths = url.pathname.split("/").filter(Boolean);
-		const path = paths.at(-1)!;
-
 		const modules = $state.snapshot(routeModules) as Record<string, ModuleData>;
 		const routeModule = modules === undefined ? undefined : modules[`/src/routes${routeId}/+page.svelte`];
 


### PR DESCRIPTION
Modernizes the service architecture by migrating from the legacy Context.Tag pattern to the newer Effect.Service pattern:

- **Simplifies service instantiation** with the new scoped factory pattern
- **Removes manual database layer management** by integrating database instances directly into service implementations
- **Streamlines transaction handling** with dedicated transaction-specific service builders
- **Consolidates debug logging** into a reusable utility function
- **Eliminates redundant imports** and unused Context dependencies

Affects character, dungeon master, log, and user services while maintaining the same public API surface.