### PR TITLE
Prevents filtering when no search terms provided

### DIFF
--- a/src/lib/components/SearchResults.svelte
+++ b/src/lib/components/SearchResults.svelte
@@ -16,7 +16,9 @@
 		(Array.isArray(text) ? text : text?.split(separator) || [])
 			.filter(
 				(item) =>
-					!filtered || (matches === 1 ? regexes.every((regex) => item.match(regex)) : regexes.some((regex) => item.match(regex)))
+					!filtered ||
+					!terms.length ||
+					(matches === 1 ? regexes.every((regex) => item.match(regex)) : regexes.some((regex) => item.match(regex)))
 			)
 			.join(separator)
 	);

--- a/src/routes/(app)/admin/users/+page.svelte
+++ b/src/routes/(app)/admin/users/+page.svelte
@@ -19,10 +19,16 @@
 	const results = $derived(search.trim() ? parser.filter(search) : data.users);
 </script>
 
-<div class="mb-4 flex flex-wrap justify-between gap-2">
+<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
 	<div class="flex w-full gap-2 sm:max-w-md md:max-w-md">
 		<Search bind:value={search} placeholder="Search by name, email, role, etc." />
 	</div>
+	<span class="badge badge-primary badge-lg">
+		{#if results.length < data.users.length}
+			Showing {results.length} of
+		{/if}
+		{data.users.length} users
+	</span>
 </div>
 <table class="linked-table bg-base-200 table w-full leading-5 max-sm:border-separate max-sm:border-spacing-y-2">
 	<thead class="max-sm:hidden">


### PR DESCRIPTION
Fixes search results behavior by adding a condition to skip filtering when no search terms are present.

Previously, the filtering logic would still attempt to process results even with empty search terms, potentially causing unexpected behavior or performance issues.