### PR TITLE
fix: handles invalid character IDs with user-friendly redirect

### DIFF
--- a/src/routes/(app)/characters/+page.svelte
+++ b/src/routes/(app)/characters/+page.svelte
@@ -52,6 +52,14 @@
 		</Dropdown>
 	</div>
 
+	{#if page.url.searchParams.get("uuid") !== undefined}
+		<div class="alert alert-warning">
+			<span class="iconify mdi--alert size-6"></span>
+			Database IDs have been changed from CUIDs to UUIDs. This will break existing links to characters, but no data has been lost.
+			You will still be able to access your characters using the new UUID going forward.
+		</div>
+	{/if}
+
 	{#if !data.characters.length}
 		<section class="bg-base-200 rounded-lg">
 			<div class="py-20 text-center">

--- a/src/routes/(app)/characters/[characterId]/+layout.server.ts
+++ b/src/routes/(app)/characters/[characterId]/+layout.server.ts
@@ -1,11 +1,15 @@
 import { characterIdSchema } from "$lib/schemas.js";
 import { run } from "$server/effect";
 import { withCharacter } from "$server/effect/characters";
-import { parse } from "valibot";
+import { redirect } from "@sveltejs/kit";
+import * as v from "valibot";
 
 export const load = (event) =>
 	run(function* () {
-		const characterId = parse(characterIdSchema, event.params.characterId);
+		const result = v.safeParse(characterIdSchema, event.params.characterId);
+		if (!result.success) throw redirect(302, "/characters?uuid");
+		const characterId = result.output;
+
 		const character = characterId === "new" ? undefined : yield* withCharacter((service) => service.get.character(characterId));
 
 		return {

--- a/src/routes/(app)/characters/[characterId]/log/[logId]/+page.server.ts
+++ b/src/routes/(app)/characters/[characterId]/log/[logId]/+page.server.ts
@@ -9,7 +9,7 @@ import { sorter } from "@sillvva/utils";
 import { redirect } from "@sveltejs/kit";
 import { Effect } from "effect";
 import { fail } from "sveltekit-superforms";
-import { parse, safeParse } from "valibot";
+import { safeParse } from "valibot";
 
 export const load = (event) =>
 	run(function* () {
@@ -57,7 +57,10 @@ export const actions = {
 			const user = event.locals.user;
 			assertUser(user);
 
-			const characterId = parse(characterIdSchema, event.params.characterId);
+			const result = safeParse(characterIdSchema, event.params.characterId);
+			if (!result.success) throw redirect(302, "/characters?uuid");
+			const characterId = result.output;
+
 			const character = yield* withCharacter((service) => service.get.character(characterId));
 			if (!character) redirect(302, "/characters");
 

--- a/src/routes/(app)/characters/[characterId]/og-image.png/+server.ts
+++ b/src/routes/(app)/characters/[characterId]/og-image.png/+server.ts
@@ -9,10 +9,13 @@ import { readFile } from "fs/promises";
 import imageSize from "image-size";
 import path from "path";
 import satori from "satori";
-import { parse } from "valibot";
+import { safeParse } from "valibot";
 
 export const GET = async ({ params, url }) => {
-	const characterId = parse(characterIdSchema, params.characterId);
+	const result = safeParse(characterIdSchema, params.characterId);
+	if (!result.success) throw error(404, "Character not found");
+	const characterId = result.output;
+
 	const character = await run(withCharacter((service) => service.get.character(characterId, true)));
 	if (!character) throw error(404, "Character not found");
 


### PR DESCRIPTION
Replaces strict parsing with safe parsing for character ID validation

Redirects users to characters page with UUID notice when ID format is invalid

Prevents crashes from malformed URLs while maintaining user experience

Addresses migration from CUIDs to UUIDs format
