### PR TITLE
fix: corrects UUID parameter handling in redirects

### DIFF
--- a/src/routes/(app)/characters/+page.svelte
+++ b/src/routes/(app)/characters/+page.svelte
@@ -52,7 +52,7 @@
 		</Dropdown>
 	</div>
 
-	{#if page.url.searchParams.get("uuid") !== undefined}
+	{#if page.url.searchParams.get("uuid")}
 		<div class="alert alert-warning">
 			<span class="iconify mdi--alert size-6"></span>
 			Database IDs have been changed from CUIDs to UUIDs. This will break existing links to characters, but no data has been lost.

--- a/src/routes/(app)/characters/[characterId]/+layout.server.ts
+++ b/src/routes/(app)/characters/[characterId]/+layout.server.ts
@@ -7,7 +7,7 @@ import * as v from "valibot";
 export const load = (event) =>
 	run(function* () {
 		const result = v.safeParse(characterIdSchema, event.params.characterId);
-		if (!result.success) throw redirect(302, "/characters?uuid");
+		if (!result.success) throw redirect(302, "/characters?uuid=1");
 		const characterId = result.output;
 
 		const character = characterId === "new" ? undefined : yield* withCharacter((service) => service.get.character(characterId));

--- a/src/routes/(app)/characters/[characterId]/edit/+page.server.ts
+++ b/src/routes/(app)/characters/[characterId]/edit/+page.server.ts
@@ -58,7 +58,7 @@ export const actions = {
 			const { firstLog, ...data } = form.data;
 
 			const result = safeParse(characterIdSchema, event.params.characterId);
-			if (!result.success) throw redirect(302, "/characters?uuid");
+			if (!result.success) throw redirect(302, "/characters?uuid=1");
 			const characterId = result.output;
 
 			return save(

--- a/src/routes/(app)/characters/[characterId]/log/[logId]/+page.server.ts
+++ b/src/routes/(app)/characters/[characterId]/log/[logId]/+page.server.ts
@@ -58,7 +58,7 @@ export const actions = {
 			assertUser(user);
 
 			const result = safeParse(characterIdSchema, event.params.characterId);
-			if (!result.success) throw redirect(302, "/characters?uuid");
+			if (!result.success) throw redirect(302, "/characters?uuid=1");
 			const characterId = result.output;
 
 			const character = yield* withCharacter((service) => service.get.character(characterId));


### PR DESCRIPTION
Updates redirect URLs to include proper parameter values and adjusts condition to check for truthy values instead of undefined

Ensures UUID migration warning displays correctly and invalid character ID redirects work as expected
