### PR TITLE
refactor: consolidates authentication logic and improves error handling

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,53 +1,10 @@
 import { building } from "$app/environment";
-import { getRequestEvent } from "$app/server";
-import { privateEnv } from "$lib/env/private";
-import { appCookieSchema, localsSessionSchema, type UserId } from "$lib/schemas";
+import { appCookieSchema } from "$lib/schemas";
+import { auth, getAuthSession } from "$server/auth";
 import { serverGetCookie } from "$server/cookie";
-import { db } from "$server/db";
-import { run } from "$server/effect";
-import { withUser } from "$server/effect/users";
 import { type Handle } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
-import { betterAuth } from "better-auth";
-import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { admin } from "better-auth/plugins/admin";
-import { passkey } from "better-auth/plugins/passkey";
 import { svelteKitHandler } from "better-auth/svelte-kit";
-import { v7 } from "uuid";
-import { parse } from "valibot";
-
-export const auth = betterAuth({
-	appName: "Adventurers League Log Sheet",
-	database: drizzleAdapter(db, {
-		provider: "pg"
-	}),
-	socialProviders: {
-		google: {
-			clientId: privateEnv.GOOGLE_CLIENT_ID,
-			clientSecret: privateEnv.GOOGLE_CLIENT_SECRET,
-			disableSignUp: privateEnv.DISABLE_SIGNUPS
-		},
-		discord: {
-			clientId: privateEnv.DISCORD_CLIENT_ID,
-			clientSecret: privateEnv.DISCORD_CLIENT_SECRET,
-			disableSignUp: privateEnv.DISABLE_SIGNUPS
-		}
-	},
-	plugins: [passkey(), admin()],
-	account: {
-		accountLinking: {
-			enabled: true
-		}
-	},
-	session: {
-		expiresIn: 60 * 60 * 24 * 30 // 30 days
-	},
-	advanced: {
-		database: {
-			generateId: () => v7()
-		}
-	}
-});
 
 const authHandler: Handle = async ({ event, resolve }) => {
 	return svelteKitHandler({ event, resolve, auth, building });
@@ -76,12 +33,3 @@ const preloadTheme: Handle = async ({ event, resolve }) => {
 };
 
 export const handle = sequence(authHandler, session, preloadTheme);
-
-export async function getAuthSession(event = getRequestEvent()) {
-	const { session, user } = (await auth.api.getSession({ headers: event.request.headers })) ?? {};
-
-	return {
-		session: session && parse(localsSessionSchema, session),
-		user: user && (await run(withUser((service) => service.get.localsUser(user.id as UserId))))
-	};
-}

--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -152,7 +152,7 @@ export function defaultDM(userId: UserId): DungeonMaster {
 
 export function defaultLogSchema(
 	userId: UserId,
-	character: { id: CharacterId | null; name: string } = { id: "" as CharacterId, name: "" }
+	character: { id: CharacterId | null; name: string } = { id: null, name: "" }
 ): LogSchema {
 	return {
 		id: "new",

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -50,7 +50,9 @@ export const envPublicSchema = v.pipe(
 interface CombinedEnv extends EnvPrivate, EnvPublic {}
 export type Env = Prettify<CombinedEnv>;
 
-export const imageUrlWithFallback = v.pipe(v.fallback(v.union([urlSchema, v.literal(BLANK_CHARACTER)]), BLANK_CHARACTER));
+export const imageUrlWithFallback = v.pipe(
+	v.fallback(v.union([urlSchema, v.literal(""), v.literal(BLANK_CHARACTER)]), BLANK_CHARACTER)
+);
 
 export type UserId = v.InferOutput<typeof userIdSchema>;
 export const userIdSchema = brandedId("UserId");
@@ -62,7 +64,7 @@ export const newCharacterSchema = v.object({
 	race: v.optional(shortString, ""),
 	class: v.optional(shortString, ""),
 	characterSheetUrl: optionalURL,
-	imageUrl: imageUrlWithFallback
+	imageUrl: v.optional(imageUrlWithFallback, "")
 });
 
 export type CharacterId = v.InferOutput<typeof characterIdSchema>;
@@ -302,6 +304,9 @@ export const localsPasskeySchema = v.object({
 	aaguid: v.nullable(v.string())
 });
 
+export type Role = v.InferOutput<typeof roleSchema>;
+export const roleSchema = v.picklist(["user", "admin"]);
+
 export type LocalsUser = v.InferOutput<typeof localsUserSchema>;
 export const localsUserSchema = v.object({
 	id: userIdSchema,
@@ -309,7 +314,7 @@ export const localsUserSchema = v.object({
 	email: requiredString,
 	emailVerified: v.boolean(),
 	image: v.nullish(imageUrlWithFallback),
-	role: v.picklist(["user", "admin"]),
+	role: roleSchema,
 	banned: v.boolean(),
 	banReason: v.nullish(v.string()),
 	banExpires: v.nullish(v.date()),

--- a/src/routes/(app)/admin/+layout.server.ts
+++ b/src/routes/(app)/admin/+layout.server.ts
@@ -1,11 +1,9 @@
-import { assertUser } from "$server/auth";
-import { redirect } from "@sveltejs/kit";
+import { assertAuth } from "$server/auth.js";
+import { run } from "$server/effect";
 
-export const load = async (event) => {
-	const user = event.locals.user;
-	assertUser(user);
+export const load = async (event) =>
+	run(function* () {
+		const user = yield* assertAuth(event, true);
 
-	if (user.role !== "admin") throw redirect(302, "/characters");
-
-	return { user };
-};
+		return { user };
+	});

--- a/src/routes/(app)/characters/+page.server.ts
+++ b/src/routes/(app)/characters/+page.server.ts
@@ -1,11 +1,10 @@
-import { assertUser } from "$server/auth";
+import { assertAuth } from "$server/auth";
 import { run } from "$server/effect";
 import { withCharacter } from "$server/effect/characters.js";
 
 export const load = (event) =>
 	run(function* () {
-		const user = event.locals.user;
-		assertUser(user);
+		const user = yield* assertAuth(event);
 
 		const characters = yield* withCharacter((service) => service.get.userCharacters(user.id, true));
 

--- a/src/routes/(app)/characters/[characterId]/+layout.server.ts
+++ b/src/routes/(app)/characters/[characterId]/+layout.server.ts
@@ -7,7 +7,7 @@ import * as v from "valibot";
 export const load = (event) =>
 	run(function* () {
 		const result = v.safeParse(characterIdOrNewSchema, event.params.characterId);
-		if (!result.success) throw redirect(302, `/characters${event.params.characterId !== "new" ? "?uuid=1" : ""}`);
+		if (!result.success) throw redirect(307, `/characters${event.params.characterId !== "new" ? "?uuid=1" : ""}`);
 		const characterId = result.output;
 
 		const character = characterId === "new" ? undefined : yield* withCharacter((service) => service.get.character(characterId));

--- a/src/routes/(app)/characters/[characterId]/+page.server.ts
+++ b/src/routes/(app)/characters/[characterId]/+page.server.ts
@@ -1,5 +1,5 @@
 import { characterIdSchema, logIdSchema } from "$lib/schemas.js";
-import { assertUser } from "$server/auth";
+import { assertAuth } from "$server/auth";
 import { run, save, validateForm } from "$server/effect";
 import { CharacterNotFoundError, withCharacter } from "$server/effect/characters";
 import { withLog } from "$server/effect/logs.js";
@@ -24,8 +24,7 @@ export const load = (event) =>
 export const actions = {
 	deleteCharacter: (event) =>
 		run(function* () {
-			const user = event.locals.user;
-			assertUser(user);
+			const user = yield* assertAuth(event);
 
 			const form = yield* validateForm(event, v.object({ id: characterIdSchema }));
 			if (!form.valid) return fail(400, { form });
@@ -43,8 +42,7 @@ export const actions = {
 		}),
 	deleteLog: (event) =>
 		run(function* () {
-			const user = event.locals.user;
-			assertUser(user);
+			const user = yield* assertAuth(event);
 
 			const form = yield* validateForm(event, v.object({ id: logIdSchema }));
 			if (!form.valid) return fail(400, { form });

--- a/src/routes/(app)/characters/[characterId]/edit/+page.svelte
+++ b/src/routes/(app)/characters/[characterId]/edit/+page.svelte
@@ -18,6 +18,7 @@
 	import Input from "$lib/components/forms/Input.svelte";
 	import Submit from "$lib/components/forms/Submit.svelte";
 	import SuperForm from "$lib/components/forms/SuperForm.svelte";
+	import { BLANK_CHARACTER } from "$lib/constants.js";
 	import { errorToast, valibotForm } from "$lib/factories.svelte.js";
 	import { editCharacterSchema } from "$lib/schemas";
 	import { getGlobal } from "$lib/stores.svelte.js";
@@ -55,20 +56,20 @@
 		<Input type="url" {superform} field="characterSheetUrl" label="Character Sheet URL" />
 	</Control>
 	<Control class="col-span-12">
-		<div class="flex items-center gap-2">
+		<div class="flex items-center gap-4">
 			<div class="flex-1">
 				<Input
 					type="url"
 					{superform}
 					field="imageUrl"
 					label="Image URL"
-					placeholder={`${page.url.origin}${data.BLANK_CHARACTER}`}
+					placeholder={`${page.url.origin}${BLANK_CHARACTER}`}
 					description="Images from imgur may not appear when sharing links due to rate limiting"
 				/>
 			</div>
 			<div class="mask mask-squircle bg-primary size-12">
 				<img
-					src={$form.imageUrl || data.BLANK_CHARACTER}
+					src={$form.imageUrl || BLANK_CHARACTER}
 					width={48}
 					height={48}
 					class="size-full object-cover object-top duration-150 ease-in-out group-hover/row:scale-125 motion-safe:transition-transform"
@@ -76,8 +77,8 @@
 					loading="lazy"
 					onerror={(e) => {
 						const img = e.currentTarget as HTMLImageElement;
-						img.src = data.BLANK_CHARACTER;
-						$form.imageUrl = data.BLANK_CHARACTER;
+						img.src = BLANK_CHARACTER;
+						$form.imageUrl = BLANK_CHARACTER;
 						errorToast("Image URL does not load. Using default image.");
 					}}
 				/>

--- a/src/routes/(app)/characters/[characterId]/log/[logId]/+page.server.ts
+++ b/src/routes/(app)/characters/[characterId]/log/[logId]/+page.server.ts
@@ -1,6 +1,6 @@
 import { defaultLogSchema, getItemEntities, logDataToSchema } from "$lib/entities.js";
 import { characterIdSchema, characterLogSchema, logIdOrNewSchema } from "$lib/schemas";
-import { assertUser } from "$server/auth";
+import { assertAuth } from "$server/auth";
 import { run, save, validateForm } from "$server/effect";
 import { CharacterNotFoundError, withCharacter } from "$server/effect/characters.js";
 import { withDM } from "$server/effect/dms.js";
@@ -13,23 +13,22 @@ import * as v from "valibot";
 
 export const load = (event) =>
 	run(function* () {
-		const user = event.locals.user;
-		assertUser(user);
+		const user = yield* assertAuth(event);
 
 		const parent = yield* Effect.promise(event.parent);
 		const character = parent.character;
 		if (!character) return yield* new CharacterNotFoundError();
 
 		const idResult = v.safeParse(logIdOrNewSchema, event.params.logId);
-		if (!idResult.success) redirect(302, `/character/${character.id}`);
+		if (!idResult.success) redirect(307, `/character/${character.id}`);
 		const logId = idResult.output;
 
 		const logData = yield* withLog((service) => service.get.log(logId, user.id));
-		let log = logData ? logDataToSchema(user.id, logData) : defaultLogSchema(user.id);
+		let log = logData ? logDataToSchema(user.id, logData) : defaultLogSchema(user.id, character);
 
 		if (logId !== "new") {
 			if (!log.id) return yield* new LogNotFoundError();
-			if (log.isDmLog) redirect(302, `/dm-logs/${log.id}`);
+			if (log.isDmLog) redirect(307, `/dm-logs/${log.id}`);
 		}
 
 		const form = yield* validateForm(log, characterLogSchema(character));
@@ -54,19 +53,18 @@ export const load = (event) =>
 export const actions = {
 	saveLog: (event) =>
 		run(function* () {
-			const user = event.locals.user;
-			assertUser(user);
+			const user = yield* assertAuth(event);
 
 			const characterId = v.parse(characterIdSchema, event.params.characterId);
 			const character = yield* withCharacter((service) => service.get.character(characterId));
-			if (!character) redirect(302, "/characters");
+			if (!character) redirect(307, "/characters");
 
 			const idResult = v.safeParse(logIdOrNewSchema, event.params.logId);
-			if (!idResult.success) redirect(302, `/character/${character.id}`);
+			if (!idResult.success) redirect(307, `/character/${character.id}`);
 			const logId = idResult.output;
 
 			const log = logId !== "new" ? yield* withLog((service) => service.get.log(logId, user.id)) : undefined;
-			if (logId !== "new" && !log?.id) redirect(302, `/characters/${character.id}`);
+			if (logId !== "new" && !log?.id) redirect(307, `/characters/${character.id}`);
 
 			const form = yield* validateForm(event, characterLogSchema(character));
 			if (!form.valid) return fail(400, { form });

--- a/src/routes/(app)/dm-logs/+page.server.ts
+++ b/src/routes/(app)/dm-logs/+page.server.ts
@@ -1,5 +1,5 @@
 import { logIdSchema } from "$lib/schemas.js";
-import { assertUser } from "$server/auth";
+import { assertAuth } from "$server/auth";
 import { run, save, validateForm } from "$server/effect";
 import { withLog } from "$server/effect/logs.js";
 import { fail, setError } from "sveltekit-superforms";
@@ -7,8 +7,7 @@ import * as v from "valibot";
 
 export const load = (event) =>
 	run(function* () {
-		const user = event.locals.user;
-		assertUser(user);
+		const user = yield* assertAuth(event);
 
 		const logs = yield* withLog((service) => service.get.dmLogs(user.id));
 
@@ -21,8 +20,7 @@ export const load = (event) =>
 export const actions = {
 	deleteLog: (event) =>
 		run(function* () {
-			const user = event.locals.user;
-			assertUser(user);
+			const user = yield* assertAuth(event);
 
 			const form = yield* validateForm(event, v.object({ id: logIdSchema }));
 			if (!form.valid) return fail(400, { form });

--- a/src/routes/(app)/dms/+page.server.ts
+++ b/src/routes/(app)/dms/+page.server.ts
@@ -1,5 +1,5 @@
 import { dungeonMasterIdSchema } from "$lib/schemas.js";
-import { assertUser } from "$server/auth";
+import { assertAuth } from "$server/auth";
 import { run, save, validateForm } from "$server/effect";
 import { withDM } from "$server/effect/dms";
 import { fail, redirect } from "@sveltejs/kit";
@@ -8,8 +8,7 @@ import * as v from "valibot";
 
 export const load = (event) =>
 	run(function* () {
-		const user = event.locals.user;
-		assertUser(user);
+		const user = yield* assertAuth(event);
 
 		const dms = yield* withDM((service) => service.get.userDMs(user));
 
@@ -22,14 +21,13 @@ export const load = (event) =>
 export const actions = {
 	deleteDM: (event) =>
 		run(function* () {
-			const user = event.locals.user;
-			assertUser(user);
+			const user = yield* assertAuth(event);
 
 			const form = yield* validateForm(event, v.object({ id: dungeonMasterIdSchema }));
 			if (!form.valid) return fail(400, { form });
 
 			const [dm] = yield* withDM((service) => service.get.userDMs(user, { id: form.data.id }));
-			if (!dm) redirect(302, "/dms");
+			if (!dm) redirect(307, "/dms");
 
 			return save(
 				withDM((service) => service.set.delete(dm, user.id)),

--- a/src/routes/(app)/dms/[dmId]/+page.server.ts
+++ b/src/routes/(app)/dms/[dmId]/+page.server.ts
@@ -1,5 +1,5 @@
 import { dungeonMasterIdSchema, dungeonMasterSchema } from "$lib/schemas";
-import { assertUser } from "$server/auth";
+import { assertAuth } from "$server/auth";
 import { run, save, validateForm } from "$server/effect";
 import { DMNotFoundError, withDM } from "$server/effect/dms";
 import { redirect } from "@sveltejs/kit";
@@ -9,13 +9,12 @@ import * as v from "valibot";
 
 export const load = (event) =>
 	run(function* () {
-		const user = event.locals.user;
-		assertUser(user);
+		const user = yield* assertAuth(event);
 
 		const parent = yield* Effect.promise(event.parent);
 
 		const idResult = v.safeParse(dungeonMasterIdSchema, event.params.dmId || "");
-		if (!idResult.success) redirect(302, `/dms`);
+		if (!idResult.success) redirect(307, `/dms`);
 		const dmId = idResult.output;
 
 		const [dm] = yield* withDM((service) => service.get.userDMs(user, { id: dmId }));
@@ -46,11 +45,10 @@ export const load = (event) =>
 export const actions = {
 	saveDM: (event) =>
 		run(function* () {
-			const user = event.locals.user;
-			assertUser(user);
+			const user = yield* assertAuth(event);
 
 			const idResult = v.safeParse(dungeonMasterIdSchema, event.params.dmId || "");
-			if (!idResult.success) redirect(302, `/dms`);
+			if (!idResult.success) redirect(307, `/dms`);
 			const dmId = idResult.output;
 
 			const form = yield* validateForm(event, dungeonMasterSchema);

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -7,7 +7,7 @@ export const load = (event) =>
 		const user = event.locals.user;
 
 		const redirectTo = event.url.searchParams.get("redirect");
-		if (user?.id) redirect(302, redirectTo || "/characters");
+		if (user?.id) redirect(307, redirectTo || "/characters");
 
 		const code = event.url.searchParams.get("code");
 		const reason = event.url.searchParams.get("reason");

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,9 +1,50 @@
 import { getRequestEvent } from "$app/server";
-import { localsUserSchema, type LocalsUser } from "$lib/schemas";
-import { redirect } from "@sveltejs/kit";
+import { privateEnv } from "$lib/env/private";
+import { localsSessionSchema, localsUserSchema, type LocalsUser, type UserId } from "$lib/schemas";
+import { redirect, type RequestEvent } from "@sveltejs/kit";
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { admin } from "better-auth/plugins/admin";
+import { passkey } from "better-auth/plugins/passkey";
 import { Effect } from "effect";
+import { v7 } from "uuid";
 import * as v from "valibot";
-import { Log } from "./effect";
+import { db } from "./db";
+import { Log, run } from "./effect";
+import { withUser } from "./effect/users";
+
+export const auth = betterAuth({
+	appName: "Adventurers League Log Sheet",
+	database: drizzleAdapter(db, {
+		provider: "pg"
+	}),
+	socialProviders: {
+		google: {
+			clientId: privateEnv.GOOGLE_CLIENT_ID,
+			clientSecret: privateEnv.GOOGLE_CLIENT_SECRET,
+			disableSignUp: privateEnv.DISABLE_SIGNUPS
+		},
+		discord: {
+			clientId: privateEnv.DISCORD_CLIENT_ID,
+			clientSecret: privateEnv.DISCORD_CLIENT_SECRET,
+			disableSignUp: privateEnv.DISABLE_SIGNUPS
+		}
+	},
+	plugins: [passkey(), admin()],
+	account: {
+		accountLinking: {
+			enabled: true
+		}
+	},
+	session: {
+		expiresIn: 60 * 60 * 24 * 30 // 30 days
+	},
+	advanced: {
+		database: {
+			generateId: () => v7()
+		}
+	}
+});
 
 export function assertUser(user: LocalsUser | undefined): asserts user is LocalsUser {
 	const event = getRequestEvent();
@@ -11,16 +52,34 @@ export function assertUser(user: LocalsUser | undefined): asserts user is Locals
 	const result = v.safeParse(localsUserSchema, user);
 	if (!result.success) {
 		Effect.runFork(Log.debug("assertUser", { issues: v.summarize(result.issues) }));
-		redirect(302, `/?redirect=${encodeURIComponent(`${url.pathname}${url.search}`)}`);
+		redirect(307, `/?redirect=${encodeURIComponent(`${url.pathname}${url.search}`)}`);
 	}
 	if (result.output.banned) {
 		event.cookies
 			.getAll()
 			.filter((c) => c.name.includes("auth"))
 			.forEach((c) => event.cookies.delete(c.name, { path: "/" }));
-		redirect(302, `/?code=BANNED&reason=${result.output.banReason}`);
+		redirect(307, `/?code=BANNED&reason=${result.output.banReason}`);
 	}
 }
+
+export async function getAuthSession(event = getRequestEvent()) {
+	const { session, user } = (await auth.api.getSession({ headers: event.request.headers })) ?? {};
+
+	return {
+		session: session && v.parse(localsSessionSchema, session),
+		user: user && (await run(withUser((service) => service.get.localsUser(user.id as UserId))))
+	};
+}
+
+export const assertAuth = Effect.fn(function* (event: RequestEvent = getRequestEvent(), adminOnly: boolean = false) {
+	const user = event.locals.user ?? (yield* Effect.promise(() => getAuthSession(event))).user;
+	assertUser(user);
+
+	if (adminOnly && user.role !== "admin") return redirect(307, "/characters");
+
+	return user;
+});
 
 export function getError(code: string | null, reason: string | null) {
 	switch (code) {

--- a/src/server/effect/index.ts
+++ b/src/server/effect/index.ts
@@ -199,8 +199,8 @@ export async function save<
 	);
 
 	if (typeof result === "string" && result.startsWith("/")) {
-		Effect.runFork(Log.debug("Redirect", { status: 302, location: result }));
-		redirect(302, result);
+		Effect.runFork(Log.debug("Redirect", { status: 307, location: result }));
+		redirect(307, result);
 	}
 
 	if (typeof result === "object" && result !== null && "status" in result) {


### PR DESCRIPTION
Moves authentication session retrieval from hooks to dedicated auth module to improve code organization and reusability.

Replaces inline user assertions with centralized authentication function that handles both regular and admin-only access patterns.

Updates error handling across services to use more specific error types for delete operations instead of generic save errors.

Standardizes HTTP redirect status codes from 302 to 307 to preserve request methods during redirects.

Fixes character image URL fallback handling and improves schema validation for empty string values.
